### PR TITLE
Allow positioning of full-size character arts in Visual Novel

### DIFF
--- a/resources/dialogs/blood.toml
+++ b/resources/dialogs/blood.toml
@@ -6,6 +6,9 @@
   [command.background]
     t = "Color"
     c = "#ff0000"
+  [command.positions]
+    Jotaro = { direction = 'L', position = 0 }
+    Dio = { direction = 'R', position = -100 }
 
 [[command]]
   text = "A MAN WAS WALKING AROUND AND BLOOD STARTED COMING OUT OF HIM EVERYWHERE."

--- a/resources/dialogs/blood.toml
+++ b/resources/dialogs/blood.toml
@@ -7,8 +7,8 @@
     t = "Color"
     c = "#ff0000"
   [command.positions]
-    Jotaro = { direction = 'L', position = 0 }
-    Dio = { direction = 'R', position = -100 }
+    Jotaro = { direction = 'L', position = -40 }
+    Dio = { direction = 'R', position = 70 }
 
 [[command]]
   text = "A MAN WAS WALKING AROUND AND BLOOD STARTED COMING OUT OF HIM EVERYWHERE."

--- a/src/engine/draw_cache.rs
+++ b/src/engine/draw_cache.rs
@@ -1,6 +1,8 @@
 use std::cell::RefCell;
 
-use ggez::{Context, GameResult, graphics::{BlendMode, DrawParam, Drawable}};
+use ggez::{graphics::{BlendMode, DrawParam, Drawable},
+           Context,
+           GameResult};
 
 pub trait TryIntoDrawable<T>
 where

--- a/src/engine/draw_cache.rs
+++ b/src/engine/draw_cache.rs
@@ -1,8 +1,8 @@
 use std::cell::RefCell;
 
-use ggez::{graphics::{BlendMode, DrawParam, Drawable},
-           Context,
-           GameResult};
+use ggez::{
+    graphics::{BlendMode, DrawParam, Drawable}, Context, GameResult,
+};
 
 pub trait TryIntoDrawable<T>
 where

--- a/src/engine/scenes/visual_novel.rs
+++ b/src/engine/scenes/visual_novel.rs
@@ -129,6 +129,18 @@ impl<F> engine::scene::Scene<Input, F> for VisualNovel {
         if let Some(ref dialog) = self.dialog {
             dialog.draw_ex(ctx, DrawParam::default())?;
         }
+        let screen_width = ctx.conf.window_mode.width;
+        for (_, draw_cache) in &self.characters {
+            let position = draw_cache.as_ref().position;
+            let x = engine::ui::to_window_position(screen_width, position);
+            draw_cache.draw_ex(
+                ctx,
+                DrawParam {
+                    dest: Point2::new(x, 0.0),
+                    ..Default::default()
+                },
+            )?;
+        }
         Ok(())
     }
 }

--- a/src/engine/scenes/visual_novel.rs
+++ b/src/engine/scenes/visual_novel.rs
@@ -25,8 +25,26 @@ impl VisualNovel {
         let commands = &mut self.commands;
         let command = &mut commands[self.command_index];
 
+        VisualNovel::apply_characters(&mut self.characters, command);
         VisualNovel::apply_dialog(&mut self.dialog, command);
         VisualNovel::apply_background(&mut self.background, command);
+    }
+
+    fn apply_characters(
+        characters: &mut HashMap<String, DrawCache<Character, Image>>,
+        command: &Command,
+    ) {
+        if let Some(ref positions) = command.positions {
+            for (name, position) in positions {
+                characters
+                    .entry(name.clone())
+                    .or_insert(DrawCache::new(Character {
+                        name: name.clone(),
+                        direction: position.direction.clone(),
+                        position: position.position.clone(),
+                    }));
+            }
+        }
     }
 
     fn apply_background(

--- a/src/engine/scenes/visual_novel.rs
+++ b/src/engine/scenes/visual_novel.rs
@@ -35,6 +35,7 @@ impl VisualNovel {
         command: &Command,
     ) {
         if let Some(ref positions) = command.positions {
+            characters.clear();
             for (name, position) in positions {
                 characters.insert(
                     name.clone(),

--- a/src/engine/scenes/visual_novel.rs
+++ b/src/engine/scenes/visual_novel.rs
@@ -17,7 +17,7 @@ pub struct VisualNovel {
     dialog: Option<DrawCache<Dialog, DialogCache>>,
     background: Option<DrawCache<Background, BackgroundCache>>,
     status: Status,
-    characters: Option<HashMap<String, DrawCache<Character, Image>>>,
+    characters: HashMap<String, DrawCache<Character, Image>>,
 }
 
 impl VisualNovel {
@@ -67,7 +67,7 @@ impl VisualNovel {
             status: Status::PendingCommands,
             dialog: None,
             background: None,
-            characters: None,
+            characters: HashMap::new(),
         }
     }
 }

--- a/src/engine/scenes/visual_novel.rs
+++ b/src/engine/scenes/visual_novel.rs
@@ -1,12 +1,13 @@
+use std::collections::HashMap;
 use std::mem;
 
 use ggez::event::Keycode::{Left, Right};
 
-use ggez::graphics::{DrawParam, Drawable, Point2};
+use ggez::graphics::{DrawParam, Drawable, Image, Point2};
 use ggez::{self, GameResult};
 
 use engine::draw_cache::DrawCache;
-use engine::ui::{Background, BackgroundCache, Dialog, DialogCache, Portrait};
+use engine::ui::{Background, BackgroundCache, Character, Dialog, DialogCache, Portrait};
 use engine::visual_novel::command::{BackgroundCommand, Command, PortraitCommand};
 use engine::{self, color};
 
@@ -18,6 +19,7 @@ pub struct VisualNovel {
     dialog: Option<DrawCache<Dialog, DialogCache>>,
     background: Option<DrawCache<Background, BackgroundCache>>,
     status: Status,
+    characters: Option<HashMap<String, DrawCache<Character, Image>>>,
 }
 
 impl VisualNovel {
@@ -67,6 +69,7 @@ impl VisualNovel {
             status: Status::PendingCommands,
             dialog: None,
             background: None,
+            characters: None,
         }
     }
 }

--- a/src/engine/scenes/visual_novel.rs
+++ b/src/engine/scenes/visual_novel.rs
@@ -1,9 +1,9 @@
+use std::mem;
+
 use ggez::event::Keycode::{Left, Right};
 
 use ggez::graphics::{DrawParam, Drawable, Point2};
 use ggez::{self, GameResult};
-
-use std::mem;
 
 use engine::draw_cache::DrawCache;
 use engine::ui::{Background, BackgroundCache, Dialog, DialogCache, Portrait};

--- a/src/engine/scenes/visual_novel.rs
+++ b/src/engine/scenes/visual_novel.rs
@@ -2,16 +2,14 @@ use std::collections::HashMap;
 use std::mem;
 
 use ggez::event::Keycode::{Left, Right};
-
 use ggez::graphics::{DrawParam, Drawable, Image, Point2};
 use ggez::{self, GameResult};
 
 use engine::draw_cache::DrawCache;
+use engine::input::Input;
 use engine::ui::{Background, BackgroundCache, Character, Dialog, DialogCache, Portrait};
 use engine::visual_novel::command::{BackgroundCommand, Command, PortraitCommand};
 use engine::{self, color};
-
-use engine::input::Input;
 
 pub struct VisualNovel {
     commands: Vec<Command>,

--- a/src/engine/scenes/visual_novel.rs
+++ b/src/engine/scenes/visual_novel.rs
@@ -36,13 +36,14 @@ impl VisualNovel {
     ) {
         if let Some(ref positions) = command.positions {
             for (name, position) in positions {
-                characters
-                    .entry(name.clone())
-                    .or_insert(DrawCache::new(Character {
+                characters.insert(
+                    name.clone(),
+                    DrawCache::new(Character {
                         name: name.clone(),
                         direction: position.direction.clone(),
                         position: position.position.clone(),
-                    }));
+                    }),
+                );
             }
         }
     }

--- a/src/engine/ui.rs
+++ b/src/engine/ui.rs
@@ -208,9 +208,9 @@ impl Drawable for BackgroundCache {
     }
 }
 
-pub fn to_window_position(ctx: &Context, position: i8) -> f32 {
+pub fn to_window_position(width: u32, position: i8) -> f32 {
     let position = position as f32;
-    let width = ctx.conf.window_mode.width as f32;
+    let width = width as f32;
 
     let half = width / 2.0;
     let shift = half * position / 100.0;

--- a/src/engine/ui.rs
+++ b/src/engine/ui.rs
@@ -207,3 +207,12 @@ impl Drawable for BackgroundCache {
         }
     }
 }
+
+pub fn to_window_position(ctx: &Context, position: i8) -> f32 {
+    let position = position as f32;
+    let width = ctx.conf.window_mode.width as f32;
+
+    let half = width / 2.0;
+    let shift = half * position / 100.0;
+    half + shift
+}

--- a/src/engine/ui.rs
+++ b/src/engine/ui.rs
@@ -29,6 +29,12 @@ pub struct Character {
     pub position: i8,
 }
 
+impl TryIntoDrawable<Image> for Character {
+    fn try_into_drawable(&self, ctx: &mut Context) -> GameResult<Image> {
+        Image::solid(ctx, 50, graphics::WHITE)
+    }
+}
+
 impl TryIntoDrawable<DialogCache> for Dialog {
     fn try_into_drawable(&self, ctx: &mut Context) -> GameResult<DialogCache> {
         let font = ctx.default_font.clone();

--- a/src/engine/ui.rs
+++ b/src/engine/ui.rs
@@ -1,5 +1,6 @@
-use ggez::graphics::{self, BlendMode, Color, DrawMode, DrawParam, Drawable, Image, Mesh, Point2,
-                     Rect, Text};
+use ggez::graphics::{
+    self, BlendMode, Color, DrawMode, DrawParam, Drawable, Image, Mesh, Point2, Rect, Text,
+};
 use ggez::{Context, GameResult};
 
 use super::draw_cache::TryIntoDrawable;

--- a/src/engine/ui.rs
+++ b/src/engine/ui.rs
@@ -216,3 +216,17 @@ pub fn to_window_position(width: u32, position: i8) -> f32 {
     let shift = half * position / 100.0;
     half + shift
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_to_window_position() {
+        assert_eq!(to_window_position(800, -100), 0.0);
+        assert_eq!(to_window_position(800, -50), 200.0);
+        assert_eq!(to_window_position(800, 0), 400.0);
+        assert_eq!(to_window_position(800, 50), 600.0);
+        assert_eq!(to_window_position(800, 100), 800.0);
+    }
+}

--- a/src/engine/ui.rs
+++ b/src/engine/ui.rs
@@ -23,6 +23,12 @@ pub struct Portrait {
     pub style: String,
 }
 
+pub struct Character {
+    pub name: String,
+    pub direction: String,
+    pub position: i8,
+}
+
 impl TryIntoDrawable<DialogCache> for Dialog {
     fn try_into_drawable(&self, ctx: &mut Context) -> GameResult<DialogCache> {
         let font = ctx.default_font.clone();

--- a/src/engine/visual_novel/command.rs
+++ b/src/engine/visual_novel/command.rs
@@ -3,6 +3,7 @@ extern crate toml;
 use std::env;
 use std::fs::File;
 use std::io::Read;
+use std::collections::HashMap;
 
 #[derive(Deserialize, Debug)]
 #[serde(tag = "t", content = "c")]
@@ -30,6 +31,7 @@ pub struct Command {
     pub background: Option<BackgroundCommand>,
     pub portrait: Option<PortraitCommand>,
     pub text: String,
+    pub positions: Option<HashMap<String, PositionCommand>>,
 }
 
 impl Command {

--- a/src/engine/visual_novel/command.rs
+++ b/src/engine/visual_novel/command.rs
@@ -1,9 +1,9 @@
 extern crate toml;
 
+use std::collections::HashMap;
 use std::env;
 use std::fs::File;
 use std::io::Read;
-use std::collections::HashMap;
 
 #[derive(Deserialize, Debug)]
 #[serde(tag = "t", content = "c")]

--- a/src/engine/visual_novel/command.rs
+++ b/src/engine/visual_novel/command.rs
@@ -20,6 +20,12 @@ pub enum PortraitCommand {
 }
 
 #[derive(Deserialize, Debug)]
+pub struct PositionCommand {
+    pub direction: String,
+    pub position: i8,
+}
+
+#[derive(Deserialize, Debug)]
 pub struct Command {
     pub background: Option<BackgroundCommand>,
     pub portrait: Option<PortraitCommand>,


### PR DESCRIPTION
For now, it is just showing tiny generated square images, but this should be easy to change when we have assets.

Closes #49 and #51 