### PR TITLE
Allow jumping to specific IDs defined in the Visual Novel DSL

### DIFF
--- a/src/engine/scenes/visual_novel.rs
+++ b/src/engine/scenes/visual_novel.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 use std::mem;
 
-use ggez::event::Keycode::{Left, Right};
+use ggez::event::Keycode::{Left, Num1, Num2, Num3, Right};
 use ggez::graphics::{DrawParam, Drawable, Image, Point2};
 use ggez::{self, GameResult};
 
@@ -125,6 +125,9 @@ impl<F> engine::scene::Scene<Input, F> for VisualNovel {
                     self.status = Status::PendingCommands;
                     x + 1
                 }
+                (Num1, _) => Self::jump(self, "blood-begin"),
+                (Num2, _) => Self::jump(self, "blood-second"),
+                (Num3, _) => Self::jump(self, "blood-end"),
                 (_, x) => x,
             }
         }

--- a/src/engine/scenes/visual_novel.rs
+++ b/src/engine/scenes/visual_novel.rs
@@ -24,6 +24,17 @@ pub struct VisualNovel {
 
 
 impl VisualNovel {
+    fn jump(&mut self, target: &str) {
+        let pred = |c: &Command| c.id == Some(target.to_string());
+        self.command_index = self
+            .commands
+            .iter()
+            .position(pred)
+            .expect(&format!("ID does not exist: {}", target));
+        self.status = Status::PendingCommands;
+    }
+
+
     fn apply(&mut self) {
         let commands = &mut self.commands;
         let command = &mut commands[self.command_index];

--- a/src/engine/scenes/visual_novel.rs
+++ b/src/engine/scenes/visual_novel.rs
@@ -24,14 +24,15 @@ pub struct VisualNovel {
 
 
 impl VisualNovel {
-    fn jump(&mut self, target: &str) {
+    fn jump(&mut self, target: &str) -> usize {
         let pred = |c: &Command| c.id == Some(target.to_string());
-        self.command_index = self
+        let new_index = self
             .commands
             .iter()
             .position(pred)
             .expect(&format!("ID does not exist: {}", target));
         self.status = Status::PendingCommands;
+        return new_index;
     }
 
 


### PR DESCRIPTION
Right now, the IDs to jump to are hard-coded, but that should be changed with #4 

Closes #61 